### PR TITLE
remove field check on custom report and get employee

### DIFF
--- a/PyBambooHR/PyBambooHR.py
+++ b/PyBambooHR/PyBambooHR.py
@@ -313,11 +313,7 @@ class PyBambooHR(object):
         field_list = [utils.underscore_to_camelcase(field) for field in field_list] if field_list else None
 
         if field_list:
-            for f in field_list:
-                if not f.startswith("custom") and not f.isdigit() and not self.employee_fields.get(f):
-                    raise UserWarning("You passed in an invalid field")
-                else:
-                    get_fields.append(f)
+            get_fields.extend(field_list)
         else:
             for field in self.employee_fields:
                 get_fields.append(field)
@@ -528,11 +524,7 @@ class PyBambooHR(object):
         get_fields = []
         field_list = [utils.underscore_to_camelcase(field) for field in field_list] if field_list else None
         if field_list:
-            for f in field_list:
-                if not f.startswith("custom") and not f.isdigit() and not self.employee_fields.get(f):
-                    raise UserWarning("You passed in an invalid field")
-                else:
-                    get_fields.append(f)
+            get_fields.extend(field_list)
         else:
             for field in self.employee_fields:
                 get_fields.append(field)


### PR DESCRIPTION
Removing the check on the field in custom report and employee endpoint. It doesn't take into account that a custom field might not start with "custom" and it can be whatever.
Also, even if we pass a not valid field, bamboo doesn't return a error, but the response just not contain that key. So it is better to just check in the response if the field we need is there.